### PR TITLE
Add Launch Support for Camera External Shutter

### DIFF
--- a/spinnaker_camera_driver/cfg/Spinnaker.cfg
+++ b/spinnaker_camera_driver/cfg/Spinnaker.cfg
@@ -200,7 +200,9 @@ trigger_modes = gen.enum([gen.const("LevelLow", str_t, "LevelLow", ""),
                           gen.const("AnyEdge", str_t, "AnyEdge", "")],
                           "Trigger Activation Modes")
 
-gen.add("trigger_activation_mode",               str_t,     SensorLevels.RECONFIGURE_RUNNING,               "Trigger Activiation Modes",                                                                 "FallingEdge",                    edit_method = trigger_modes)
+# Trigger Activation Modes: Used to specify the voltage level or transition that activates a trigger.
+#   Setting default to "RisingEdge" matches the Arduino Sync Module specifications
+gen.add("trigger_activation_mode",               str_t,     SensorLevels.RECONFIGURE_RUNNING,               "Trigger Activiation Modes",                                                                 "RisingEdge",                    edit_method = trigger_modes)
 
 trigger_sources = gen.enum([gen.const("Software", str_t, "Software", ""),
                             gen.const("Line0", str_t, "Line0", ""),
@@ -241,7 +243,12 @@ gen.add("trigger_overlap_mode",                   str_t,    SensorLevels.RECONFI
 
 
 # gen.add("enable_trigger_delay",                 bool_t,   SensorLevels.RECONFIGURE_RUNNING,                 "Whether Trigger Delay is active.",                                                           False)
-# gen.add("trigger_delay",                        double_t, SensorLevels.RECONFIGURE_RUNNING,                 "The trigger delay to wait once triggered (in seconds).",                                     0.0,                             0.0,            1.0)
+
+# Trigger Delay: Specify the time in microseconds between when the camera receives a trigger and when exposure begins for the image.
+#   Minimimum delay varies per Blackfly models. Model 32S4 = 13; Model 51S5 = 14; Model 89S6 = 22
+#   Setting default to "0" ensures all models use the minimum delay.
+#   Setting default to "22" ensures all models have the same syncronized delay.
+gen.add("trigger_delay",                        double_t, SensorLevels.RECONFIGURE_RUNNING,                 "The trigger delay to wait once triggered (in seconds).",                                     0.0,                             22.0,            30000.0)
 # gen.add("trigger_parameter",                    int_t,    SensorLevels.RECONFIGURE_RUNNING,                 "Trigger mode parameter.  Varies based on mode.",                                             0,                               -32768,         32767)
 
 line_sources = gen.enum([gen.const("LineSource_Off", str_t, "Off", ""),

--- a/spinnaker_camera_driver/src/camera.cpp
+++ b/spinnaker_camera_driver/src/camera.cpp
@@ -83,6 +83,8 @@ void Camera::setNewConfiguration(const SpinnakerConfig& config, const uint32_t& 
     setProperty(node_map_, "TriggerSource", config.trigger_source);
     setProperty(node_map_, "TriggerSelector", config.trigger_selector);
     setProperty(node_map_, "TriggerActivation", config.trigger_activation_mode);
+    setProperty(node_map_, "TriggerOverlap", config.trigger_overlap_mode);
+    setProperty(node_map_, "TriggerDelay", static_cast<float>(config.trigger_delay));
     setProperty(node_map_, "TriggerMode", config.enable_trigger);
 
     setProperty(node_map_, "LineSelector", config.line_selector);


### PR DESCRIPTION
### Spinnaker.cfg
Change the default config to support the external trigger feature. Settings
changed are specific to the external trigger and should not affect
functionality if the external trigger is disabled.

Change the default trigger_activation_mode setting to RisingEdge to match
the signal from the Arduino Sync Module. This setting is used only when
the external trigger is enabled.

Allow the trigger_delay setting to be configured, increase the maximum delay
limit to 30[ms], and set the default to 22[us]. This setting is used only
when the external trigger is enabled. The maximum delay is just an arbitrary
number (absolute maximum on the Blackfly 51S5 appears to be 65.520[ms]). The
default delay is based on the minimum delay of the Blackfly 89S6 model, which
is higher than all other models. By setting all delays equal, all cameras
begin their exposure at the same time and the only remaining time difference
between images are due to the auto exposure time.

### camera.cpp
Read new settings required for dynamic configuration of the external trigger
feature.

Previously, the trigger_overlap_mode was configured but not read. Now we
actually read the value.

Read the new trigger_delay setting.

-------
### Additional Notes/Observations
#### First Note
The maximum FPS limit set in the acquistion_frame_rate parameter is enforced
when the acquistion_frame_rate_enable setting is enabled, even if manually
capturing through an external trigger. Currently, the default is
acquistion_frame_rate_enable set to enabled and acquistion_frame_rate set to
30[hz] maximum FPS. Under these settings, an external trigger can control the
FPS accurately between 0[hz] to 30[hz], but not higher. Attempting to go
higher than the configured acquistion_frame_rate results in unexpected
behaviour as the PWM continues to change.

For example, setting a PWM for 32[hz] might produce 29 FPS and 45[hz] might
produce 15 FPS (these are just examples, the resulting FPS might be
different).

For now, this is not an issue since we want to limit all cameras to 30[hz]
max FPS. However, if tomorrow we want to vary the FPS (i.e. low res cameras
running @ >30[hz]), then the current setup is somewhat convoluted in that
the external shutter controls the FPS but is overridden by another setting
when certain conditions are met. If not well documented, this could lead to
a toubleshooting headache.

Long term, we may want to consider setting acquistion_frame_rate_enable to
disabled when using an external trigger and allow the external trigger to
control the maximum FPS.

#### Second Note
The maximum achievable FPS is directly affected by the exposure time.
Currently, the exposure time is set to be automatically calculated by the
camera and the auto_exposure_time_upper_limit is set to 32.754[ms]. This
upper limit allows a worse case of >=30 FPS. If tomorrow we decide to vary
the FPS, we should consider how this upper limit affects FPS.

For example, to guarrantee 40 FPS, we would have to set the upper limit to
24.367[ms]. We could also increase this limit if we decide to lower FPS.

### PR's linked to this PR
[PR in ascent_car](https://github.com/ascentai/ascent_car/pull/117)
[PR in car_cfg](https://github.com/ascentai/car_cfg/pull/51)

All three PR's are required for testing new functionality....

# Basic Validation
See the [PR in car_cfg](https://github.com/ascentai/car_cfg/pull/51) for basic validation steps...